### PR TITLE
Add support for Oro Platform 3+

### DIFF
--- a/Aligent/DBToolsBundle/Command/AbstractCommand.php
+++ b/Aligent/DBToolsBundle/Command/AbstractCommand.php
@@ -40,9 +40,9 @@ abstract class AbstractCommand extends ContainerAwareCommand
         }
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    public function setDatabaseHelper($database)
     {
-      $this->database = $this->getContainer()->get('aligent_db_tools.helper.database');
+      $this->database = $database;
     }
 
     /**

--- a/Aligent/DBToolsBundle/Command/DumpCommand.php
+++ b/Aligent/DBToolsBundle/Command/DumpCommand.php
@@ -68,7 +68,7 @@ class DumpCommand extends AbstractCommand
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        parent::initialize($input, $output); // Parent init first we need db deets
+        parent::initialize($input, $output);
         $this->loadTableDefinitions(); // Get table alias groupings from table_groups.yml
     }
 

--- a/Aligent/DBToolsBundle/DependencyInjection/AligentDBToolsExtension.php
+++ b/Aligent/DBToolsBundle/DependencyInjection/AligentDBToolsExtension.php
@@ -29,5 +29,6 @@ class AligentDBToolsExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('commands.yml');
     }
 }

--- a/Aligent/DBToolsBundle/Resources/config/commands.yml
+++ b/Aligent/DBToolsBundle/Resources/config/commands.yml
@@ -1,0 +1,42 @@
+services:
+  Aligent\DBToolsBundle\Command\ConsoleCommand:
+    class: Aligent\DBToolsBundle\Command\ConsoleCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\CreateCommand:
+    class: Aligent\DBToolsBundle\Command\CreateCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\DropCommand:
+    class: Aligent\DBToolsBundle\Command\DropCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\DumpCommand:
+    class: Aligent\DBToolsBundle\Command\DumpCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\ImportCommand:
+    class: Aligent\DBToolsBundle\Command\ImportCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\InfoCommand:
+    class: Aligent\DBToolsBundle\Command\InfoCommand
+    public: false
+    tags:
+      - { name: console.command }
+
+  Aligent\DBToolsBundle\Command\QueryCommand:
+    class: Aligent\DBToolsBundle\Command\QueryCommand
+    public: false
+    tags:
+      - { name: console.command }

--- a/Aligent/DBToolsBundle/Resources/config/commands.yml
+++ b/Aligent/DBToolsBundle/Resources/config/commands.yml
@@ -1,41 +1,53 @@
 services:
+  Aligent\DBToolsBundle\Command\AbstractCommand:
+    class: Aligent\DBToolsBundle\Command\AbstractCommand
+    calls:
+      - [setDatabaseHelper, ['@aligent_db_tools.helper.database']]
+
   Aligent\DBToolsBundle\Command\ConsoleCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\ConsoleCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\CreateCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\CreateCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\DropCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\DropCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\DumpCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\DumpCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\ImportCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\ImportCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\InfoCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\InfoCommand
     public: false
     tags:
       - { name: console.command }
 
   Aligent\DBToolsBundle\Command\QueryCommand:
+    parent: Aligent\DBToolsBundle\Command\AbstractCommand
     class: Aligent\DBToolsBundle\Command\QueryCommand
     public: false
     tags:

--- a/Aligent/DBToolsBundle/Resources/config/services.yml
+++ b/Aligent/DBToolsBundle/Resources/config/services.yml
@@ -7,10 +7,13 @@ services:
     arguments:
         - '%aligent_db_tools.parameters.yml%'
   aligent_db_tools.helper.database:
+    public: true
     class: 'Aligent\DBToolsBundle\Helper\DatabaseHelper'
     arguments:
         - '@aligent_db_tools.helper.db_settings'
   aligent_db_tools.helper.compressor.gzip:
+    public: true
     class: 'Aligent\DBToolsBundle\Helper\Compressor\Gzip'
   aligent_db_tools.helper.compressor.uncompressed:
+    public: true
     class: 'Aligent\DBToolsBundle\Helper\Compressor\Uncompressed'

--- a/Aligent/DBToolsBundle/Resources/config/services.yml
+++ b/Aligent/DBToolsBundle/Resources/config/services.yml
@@ -1,5 +1,5 @@
 parameters:
-  aligent_db_tools.parameters.yml: '%kernel.root_dir%/config/parameters.yml'
+  aligent_db_tools.parameters.yml: '%kernel.root_dir%/../config/parameters.yml'
 
 services:
   aligent_db_tools.helper.db_settings:
@@ -7,13 +7,12 @@ services:
     arguments:
         - '%aligent_db_tools.parameters.yml%'
   aligent_db_tools.helper.database:
-    public: true
     class: 'Aligent\DBToolsBundle\Helper\DatabaseHelper'
     arguments:
         - '@aligent_db_tools.helper.db_settings'
   aligent_db_tools.helper.compressor.gzip:
-    public: true
     class: 'Aligent\DBToolsBundle\Helper\Compressor\Gzip'
-  aligent_db_tools.helper.compressor.uncompressed:
     public: true
+  aligent_db_tools.helper.compressor.uncompressed:
     class: 'Aligent\DBToolsBundle\Helper\Compressor\Uncompressed'
+    public: true

--- a/Aligent/DBToolsBundle/Resources/config/services.yml
+++ b/Aligent/DBToolsBundle/Resources/config/services.yml
@@ -1,5 +1,5 @@
 parameters:
-  aligent_db_tools.parameters.yml: %kernel.root_dir%/config/parameters.yml
+  aligent_db_tools.parameters.yml: '%kernel.root_dir%/config/parameters.yml'
 
 services:
   aligent_db_tools.helper.db_settings:
@@ -9,7 +9,7 @@ services:
   aligent_db_tools.helper.database:
     class: 'Aligent\DBToolsBundle\Helper\DatabaseHelper'
     arguments:
-        - @aligent_db_tools.helper.db_settings
+        - '@aligent_db_tools.helper.db_settings'
   aligent_db_tools.helper.compressor.gzip:
     class: 'Aligent\DBToolsBundle\Helper\Compressor\Gzip'
   aligent_db_tools.helper.compressor.uncompressed:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Aligent Database Tools Bundle for OroCRM
 
 Facts
 -----
-- version: 1.0.0
+- version: 2.0.0
 - composer name: aligent/oro-dbtools
 
 Description
@@ -57,7 +57,7 @@ Licence
 
 Copyright
 ---------
-(c) 2017 Aligent Consulting
+(c) 2017-19 Aligent Consulting
 
 Thanks
 ---------

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aligent/oro-dbtools",
     "description": "Database tools bundle for Orocrm",
     "require": {
-        "oro/platform": "^2.1",
+        "oro/platform": ">=2.1",
         "php": ">=7.0"
     },
     "license": "OSL-3.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "oro/platform": ">=2.1",
         "php": ">=7.0"
     },
-    "license": "OSL-3.0",
+    "license": "MIT",
     "authors": [
         {
             "name": "Adam Hall",


### PR DESCRIPTION
Changes required to allow this bundle to work on Oro Platform 3.x and later.  Changed composer dependency requirements.  Modifications for the Symfony 3.x DI container changes (everything private by default).  Also commands now resolved via DI container.

Unfortunately I did also have to change the path in services.yml, so this likely breaks backwards compatibility with older versions of Platform.  Consequently the version number in the README has been adjusted accordingly.